### PR TITLE
feat: Add configurable coverage threshold for spec-coverage linter

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -86,7 +86,7 @@ jobs:
     - name: Validate spec coverage
       run: |
         source .venv/bin/activate
-        spec-tools check-coverage || echo "⚠️  Spec coverage not at 100% yet (aspirational goal)"
+        spec-tools check-coverage
 
     - name: Validate spec schema
       run: |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -78,5 +78,8 @@ exclude_lines = [
 allowlist = ".specallowlist"
 use_gitignore = true
 
+[tool.spec-tools.check-coverage]
+min_coverage = 88.4
+
 [tool.spec-tools.check-schema]
 use_gitignore = true

--- a/spec_tools/cli.py
+++ b/spec_tools/cli.py
@@ -112,10 +112,15 @@ def cmd_check_coverage(args) -> int:
         Exit code (0 for success, 1 for failure).
     """
     try:
+        # Load config from pyproject.toml and merge with CLI args
+        config = load_config(Path(args.directory))
+        merged_config = merge_config_with_args(config, args, "check-coverage")
+
         linter = SpecCoverageLinter(
             root_dir=Path(args.directory),
             specs_dir=Path(args.specs_dir) if args.specs_dir else None,
             tests_dir=Path(args.tests_dir) if args.tests_dir else None,
+            min_coverage=merged_config["min_coverage"],
         )
 
         # Run linter
@@ -457,6 +462,13 @@ Test marking format:
         "-v",
         action="store_true",
         help="Verbose output",
+    )
+
+    check_coverage_parser.add_argument(
+        "--min-coverage",
+        type=float,
+        default=None,
+        help="Minimum acceptable coverage percentage (default: 100.0 or from pyproject.toml)",
     )
 
     check_coverage_parser.set_defaults(func=cmd_check_coverage)

--- a/spec_tools/config.py
+++ b/spec_tools/config.py
@@ -70,6 +70,14 @@ class Config:
         """
         return self.get("check-schema", {})
 
+    def get_check_coverage_config(self) -> dict[str, Any]:
+        """Get check-coverage-specific configuration.
+
+        Returns:
+            Dictionary of check-coverage configuration values.
+        """
+        return self.get("check-coverage", {})
+
 
 def find_pyproject_toml(start_path: Path | None = None) -> Path | None:
     """Find pyproject.toml by walking up the directory tree.
@@ -138,7 +146,7 @@ def merge_config_with_args(config: Config, args: Any, command: str) -> dict[str,
     Args:
         config: Config object from pyproject.toml.
         args: Parsed command-line arguments.
-        command: Command name ('lint', 'check-links', or 'check-schema').
+        command: Command name ('lint', 'check-links', 'check-schema', or 'check-coverage').
 
     Returns:
         Dictionary of merged configuration values.
@@ -224,5 +232,16 @@ def merge_config_with_args(config: Config, args: Any, command: str) -> dict[str,
             result["respect_gitignore"] = cmd_config["use_gitignore"]
         else:
             result["respect_gitignore"] = True
+
+    elif command == "check-coverage":
+        cmd_config = config.get_check_coverage_config()
+
+        # min_coverage
+        if hasattr(args, "min_coverage") and args.min_coverage is not None:
+            result["min_coverage"] = args.min_coverage
+        elif "min_coverage" in cmd_config:
+            result["min_coverage"] = cmd_config["min_coverage"]
+        else:
+            result["min_coverage"] = 100.0
 
     return result

--- a/spec_tools/spec_coverage_linter.py
+++ b/spec_tools/spec_coverage_linter.py
@@ -66,6 +66,7 @@ class SpecCoverageLinter:
         specs_dir: Path | None = None,
         tests_dir: Path | None = None,
         root_dir: Path | None = None,
+        min_coverage: float = 100.0,
     ):
         """Initialize the spec coverage linter.
 
@@ -73,10 +74,12 @@ class SpecCoverageLinter:
             specs_dir: Directory containing spec files (default: root_dir/specs)
             tests_dir: Directory containing test files (default: root_dir/tests)
             root_dir: Root directory of the project (default: current directory)
+            min_coverage: Minimum acceptable coverage percentage (default: 100.0)
         """
         self.root_dir = Path(root_dir) if root_dir else Path.cwd()
         self.specs_dir = Path(specs_dir) if specs_dir else self.root_dir / "specs"
         self.tests_dir = Path(tests_dir) if tests_dir else self.root_dir / "tests"
+        self.min_coverage = min_coverage
 
     def extract_requirements_from_spec(self, spec_file: Path) -> set[str]:
         """Extract all requirement IDs from a spec file.
@@ -256,8 +259,8 @@ class SpecCoverageLinter:
             (covered_count / total_requirements * 100) if total_requirements > 0 else 0.0
         )
 
-        # Validation passes if all requirements are covered
-        is_valid = len(uncovered_requirements) == 0
+        # Validation passes if coverage meets or exceeds minimum threshold
+        is_valid = coverage_percentage >= self.min_coverage
 
         return SpecCoverageResult(
             total_requirements=total_requirements,

--- a/specs/spec-coverage-linter.md
+++ b/specs/spec-coverage-linter.md
@@ -1,0 +1,209 @@
+# Specification: Spec Coverage Linter
+
+**ID**: SPEC-003
+**Version**: 1.0
+**Date**: 2025-10-22
+**Status**: Draft
+
+## Overview
+
+This specification defines the requirements for a spec coverage linter tool that validates test-to-requirement traceability by ensuring all specification requirements have corresponding test cases.
+
+## Requirements (EARS Format)
+
+### Requirement Extraction
+
+**REQ-001**: The system shall scan the specs directory to find all markdown files containing requirement definitions.
+
+**REQ-002**: The system shall extract requirement IDs from spec files using the pattern `**REQ-XXX**:`, `**NFR-XXX**:`, or `**TEST-XXX**:` where XXX is a three-digit number.
+
+**REQ-003**: The system shall support custom requirement ID prefixes beyond REQ, NFR, and TEST.
+
+### Test Discovery
+
+**REQ-004**: The system shall scan the tests directory to find all Python test files matching the pattern `test_*.py`.
+
+**REQ-005**: The system shall parse test files using AST to extract test function definitions.
+
+**REQ-006**: The system shall identify test functions by the naming pattern starting with `test_`.
+
+**REQ-007**: The system shall extract requirement markers from test decorators in the format `@pytest.mark.req("REQ-XXX")`.
+
+**REQ-008**: The system shall support test functions with multiple requirement markers.
+
+**REQ-009**: WHEN a test function is defined within a class, the system shall construct the full test name as `ClassName::test_function_name`.
+
+### Coverage Analysis
+
+**REQ-010**: The system shall create a mapping from requirement IDs to test names that cover them.
+
+**REQ-011**: The system shall identify all requirements that have no corresponding test coverage.
+
+**REQ-012**: The system shall calculate the coverage percentage as (covered requirements / total requirements) × 100.
+
+**REQ-013**: The system shall identify all test functions that have no requirement markers.
+
+### Configuration
+
+**REQ-014**: The system shall support loading configuration from `pyproject.toml` under the section `[tool.spec-tools.check-coverage]`.
+
+**REQ-015**: The system shall accept a `min_coverage` configuration option to specify the minimum acceptable coverage percentage.
+
+**REQ-016**: WHERE no `min_coverage` is configured, the system shall default to requiring 100% coverage.
+
+**REQ-017**: The system shall accept `min_coverage` values from 0 to 100 representing the percentage threshold.
+
+**REQ-018**: WHEN coverage percentage is greater than or equal to `min_coverage`, the system shall report validation as passed.
+
+**REQ-019**: WHEN coverage percentage is less than `min_coverage`, the system shall report validation as failed.
+
+### Command-Line Interface
+
+**REQ-020**: The system shall accept a command-line option to specify the root directory to scan.
+
+**REQ-021**: WHERE the root directory is not specified, the system shall default to the current working directory.
+
+**REQ-022**: The system shall accept a `--specs-dir` option to specify a custom specs directory.
+
+**REQ-023**: WHERE specs directory is not specified, the system shall default to `<root-dir>/specs`.
+
+**REQ-024**: The system shall accept a `--tests-dir` option to specify a custom tests directory.
+
+**REQ-025**: WHERE tests directory is not specified, the system shall default to `<root-dir>/tests`.
+
+**REQ-026**: The system shall accept a `--verbose` option to enable detailed output.
+
+**REQ-027**: The system shall accept a `--min-coverage` option to override the configured minimum coverage percentage.
+
+**REQ-028**: WHEN both pyproject.toml configuration and command-line option are provided, the system shall use the command-line option value.
+
+### Reporting
+
+**REQ-029**: The system shall display a coverage report showing the coverage percentage.
+
+**REQ-030**: The system shall display the number of covered requirements out of total requirements.
+
+**REQ-031**: The system shall display the number of tests linked to requirements out of total tests.
+
+**REQ-032**: WHEN uncovered requirements exist, the system shall list each uncovered requirement ID.
+
+**REQ-033**: WHEN tests without requirement markers exist, the system shall list each test name.
+
+**REQ-034**: The system shall display a validation status indicating whether coverage meets the minimum threshold.
+
+**REQ-035**: IF coverage meets or exceeds the minimum threshold, THEN the system shall exit with code 0.
+
+**REQ-036**: IF coverage is below the minimum threshold, THEN the system shall exit with code 1.
+
+### Error Handling
+
+**REQ-037**: IF a spec file cannot be read, THEN the system shall print a warning and continue processing other files.
+
+**REQ-038**: IF a test file cannot be parsed, THEN the system shall print a warning and continue processing other files.
+
+**REQ-039**: WHEN unexpected errors occur, the system shall report the error to stderr.
+
+**REQ-040**: WHEN verbose mode is enabled and unexpected errors occur, the system shall include the full stack trace.
+
+## Configuration File Format
+
+The spec coverage linter supports configuration via `pyproject.toml`:
+
+```toml
+[tool.spec-tools.check-coverage]
+min_coverage = 88.4  # Minimum acceptable coverage percentage (0-100)
+```
+
+### Configuration Options
+
+- `min_coverage` (float, default: 100.0): Minimum acceptable coverage percentage
+  - Valid range: 0.0 to 100.0
+  - Validation passes when coverage >= min_coverage
+  - Can be overridden via `--min-coverage` command-line option
+
+## Examples
+
+### Running with Default 100% Coverage
+
+```bash
+spec-tools check-coverage
+```
+
+Expected output when coverage is below 100%:
+```
+============================================================
+SPEC COVERAGE REPORT
+============================================================
+Coverage: 88.4%
+Requirements: 61/69 covered
+Tests: 65/119 linked to requirements
+
+❌ Uncovered Requirements:
+  - NFR-001
+  - REQ-036
+  - REQ-037
+
+❌ Spec coverage validation FAILED
+============================================================
+```
+
+Exit code: 1
+
+### Running with Configured Minimum Coverage
+
+With `pyproject.toml`:
+```toml
+[tool.spec-tools.check-coverage]
+min_coverage = 85.0
+```
+
+```bash
+spec-tools check-coverage
+```
+
+Expected output:
+```
+============================================================
+SPEC COVERAGE REPORT
+============================================================
+Coverage: 88.4%
+Requirements: 61/69 covered
+Tests: 65/119 linked to requirements
+
+✅ Spec coverage validation PASSED
+============================================================
+```
+
+Exit code: 0
+
+### Overriding via Command Line
+
+```bash
+spec-tools check-coverage --min-coverage 90.0
+```
+
+This overrides any pyproject.toml configuration.
+
+## Non-Functional Requirements
+
+**NFR-001**: The system shall parse test files efficiently using AST without executing them.
+
+**NFR-002**: The system shall provide clear, actionable reports identifying which requirements lack coverage.
+
+**NFR-003**: The system shall support gradual coverage improvement by allowing configurable thresholds.
+
+## Test Coverage
+
+**TEST-001**: Unit tests shall cover requirement extraction from spec files with various ID formats.
+
+**TEST-002**: Unit tests shall cover test function discovery and requirement marker extraction.
+
+**TEST-003**: Unit tests shall cover coverage calculation with full, partial, and zero coverage scenarios.
+
+**TEST-004**: Unit tests shall cover configuration loading from pyproject.toml.
+
+**TEST-005**: Unit tests shall cover command-line argument parsing and precedence.
+
+**TEST-006**: Unit tests shall cover validation logic with various threshold values.
+
+**TEST-007**: Integration tests shall validate the tool against real spec and test files.


### PR DESCRIPTION
This commit implements a configurable minimum coverage threshold for the spec-coverage linter, enabling gradual coverage improvement without blocking CI. The change allows teams to enforce their current coverage level while working towards 100% coverage.

Changes:
- Add spec-coverage-linter.md specification with 40 requirements
- Extend Config class with get_check_coverage_config() method
- Update merge_config_with_args() to handle check-coverage command
- Modify SpecCoverageLinter to accept min_coverage parameter
- Update CLI to load config and pass min_coverage to linter
- Add --min-coverage option to override configured threshold
- Configure pyproject.toml with min_coverage = 88.4 (current level)
- Remove echo workaround from CI workflow to enforce threshold

The implementation follows the existing configuration pattern used by other linters (lint, check-links, check-schema). Command-line arguments take precedence over pyproject.toml configuration, with a default of 100% when not configured.

🤖 Generated with [Claude Code](https://claude.com/claude-code)