### PR TITLE
chore: Rename repository references from spec-tools to spec-check

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -1,6 +1,6 @@
 # GitHub Actions Workflows
 
-This directory contains all CI/CD workflows for spec-tools.
+This directory contains all CI/CD workflows for spec-check.
 
 ## Workflows Overview
 
@@ -11,7 +11,7 @@ This directory contains all CI/CD workflows for spec-tools.
 
 **Jobs:**
 - **test**: Runs pytest on Python 3.10, 3.11, 3.12, 3.13 with coverage
-- **lint**: Runs ruff check/format and all spec-tools linters
+- **lint**: Runs ruff check/format and all spec-check linters
 
 **When it fails:** Fix the code - all checks must pass before merging
 
@@ -109,7 +109,7 @@ This directory contains all CI/CD workflows for spec-tools.
 **What happens next:**
 - GitHub release triggers `publish.yml`
 - Package is published to PyPI
-- Users can install with `pip install spec-tools`
+- Users can install with `pip install spec-check`
 
 ---
 
@@ -151,7 +151,7 @@ create-release.yml: Creates GitHub release v0.2.0
     ↓                    ↓
 publish.yml: Publishes to PyPI
     ↓
-Package available: pip install spec-tools
+Package available: pip install spec-check
 
 
 ┌─────────────────────────────────────────────────────────────┐
@@ -192,8 +192,8 @@ Two environments must be configured in GitHub Settings:
 
 Must be configured on both PyPI and TestPyPI:
 
-- Project name: `spec-tools`
-- Repository: `TradeMe/spec-tools`
+- Project name: `spec-check`
+- Repository: `TradeMe/spec-check`
 - Workflow: `publish.yml`
 - Environments: `pypi` and `testpypi`
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,13 +64,13 @@ jobs:
       run: uv run ruff format --check spec_tools/ tests/
 
     - name: Validate file allowlist
-      run: uv run spec-tools lint --verbose
+      run: uv run spec-check lint --verbose
 
     - name: Validate spec-test structure
-      run: uv run spec-tools check-structure
+      run: uv run spec-check check-structure
 
     - name: Validate spec coverage
-      run: uv run spec-tools check-coverage
+      run: uv run spec-check check-coverage
 
     - name: Validate spec schema
-      run: uv run spec-tools check-schema --verbose
+      run: uv run spec-check check-schema --verbose

--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -88,8 +88,8 @@ jobs:
           # Update the link references at the bottom
           echo ""
           PREV_VERSION=$(sed -n 's/^## \[\([0-9][^]]*\)\].*/\1/p' CHANGELOG.md | head -2 | tail -1)
-          echo "[Unreleased]: https://github.com/TradeMe/spec-tools/compare/v$VERSION...HEAD"
-          echo "[$VERSION]: https://github.com/TradeMe/spec-tools/compare/v$PREV_VERSION...v$VERSION"
+          echo "[Unreleased]: https://github.com/TradeMe/spec-check/compare/v$VERSION...HEAD"
+          echo "[$VERSION]: https://github.com/TradeMe/spec-check/compare/v$PREV_VERSION...v$VERSION"
           sed -n '/^\[[0-9]/p' CHANGELOG.md | grep -v "^\[Unreleased\]" | grep -v "^\[$VERSION\]"
         } > CHANGELOG.md.tmp
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -101,7 +101,7 @@ jobs:
     runs-on: ubuntu-latest
     environment:
       name: pypi
-      url: https://pypi.org/p/sdd-tools
+      url: https://pypi.org/p/spec-check
     permissions:
       id-token: write
 
@@ -125,7 +125,7 @@ jobs:
     continue-on-error: true  # Don't fail the workflow if TestPyPI is not configured
     environment:
       name: testpypi
-      url: https://test.pypi.org/p/sdd-tools
+      url: https://test.pypi.org/p/spec-check
     permissions:
       id-token: write
 
@@ -148,11 +148,11 @@ jobs:
       with:
         script: |
           const version = '${{ needs.build.outputs.version }}';
-          const message = `🚀 Published development version \`${version}\` to [TestPyPI](https://test.pypi.org/project/sdd-tools/${version}/)
+          const message = `🚀 Published development version \`${version}\` to [TestPyPI](https://test.pypi.org/project/spec-check/${version}/)
 
           Install with:
           \`\`\`bash
-          pip install --index-url https://test.pypi.org/simple/ --extra-index-url https://pypi.org/simple/ sdd-tools==${version}
+          pip install --index-url https://test.pypi.org/simple/ --extra-index-url https://pypi.org/simple/ spec-check==${version}
           \`\`\``;
 
           // Find the PR that was merged

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,27 +25,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [0.1.0] - Initial Release
 
 ### Added
-- File allowlist linter (`spec-tools lint`)
+- File allowlist linter (`spec-check lint`)
   - Validates all files match gitignore-style patterns
   - Respects `.gitignore` by default
   - Supports complex patterns including character classes
-- Markdown link validator (`spec-tools check-links`)
+- Markdown link validator (`spec-check check-links`)
   - Validates internal links and anchors
   - Checks external URLs for accessibility
   - Supports private URL patterns
   - Concurrent external URL checking
-- Spec coverage validator (`spec-tools check-coverage`)
+- Spec coverage validator (`spec-check check-coverage`)
   - Extracts requirements from spec files
   - Validates test coverage using pytest markers
   - Reports coverage percentage and uncovered requirements
-- Structure validator (`spec-tools check-structure`)
+- Structure validator (`spec-check check-structure`)
   - Enforces consistent spec-to-test structure alignment
   - Supports flexible naming conventions
   - Allows unit tests without corresponding specs
-- Unique spec ID validator (`spec-tools check-unique-specs`)
+- Unique spec ID validator (`spec-check check-unique-specs`)
   - Validates spec IDs are unique across files
   - Validates requirement IDs are unique within specs
-- Markdown schema validator (`spec-tools check-schema`)
+- Markdown schema validator (`spec-check check-schema`)
   - Validates markdown files against configurable schemas
   - Supports EARS requirement validation
   - Configurable metadata and heading requirements
@@ -53,5 +53,5 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - CLI with comprehensive help text
 - Support for Python 3.10, 3.11, 3.12, 3.13
 
-[Unreleased]: https://github.com/TradeMe/spec-tools/compare/v0.1.0...HEAD
-[0.1.0]: https://github.com/TradeMe/spec-tools/releases/tag/v0.1.0
+[Unreleased]: https://github.com/TradeMe/spec-check/compare/v0.1.0...HEAD
+[0.1.0]: https://github.com/TradeMe/spec-check/releases/tag/v0.1.0

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -207,10 +207,10 @@ The CI runs the following checks:
 **Linting:**
 - `ruff check` (code quality)
 - `ruff format --check` (formatting)
-- `spec-tools lint` (file allowlist)
-- `spec-tools check-structure` (spec-test structure)
-- `spec-tools check-coverage` (requirement coverage)
-- `spec-tools check-schema` (markdown schema)
+- `spec-check lint` (file allowlist)
+- `spec-check check-structure` (spec-test structure)
+- `spec-check check-coverage` (requirement coverage)
+- `spec-check check-schema` (markdown schema)
 
 All of these must pass for CI to succeed.
 

--- a/FEATURES.md
+++ b/FEATURES.md
@@ -1,13 +1,13 @@
-# Spec-Tools Features and Roadmap
+# Spec-Check Features and Roadmap
 
-This document tracks implemented features and planned milestones for the spec-tools project.
+This document tracks implemented features and planned milestones for the spec-check project.
 
 ## Released Features
 
 ### Release 0.1.0 (Current)
 
 #### File Allowlist Validation (`lint`)
-- **Command**: `spec-tools lint`
+- **Command**: `spec-check lint`
 - **Specification**: N/A (core utility)
 - **Description**: Validates that all files in a repository match patterns in an allowlist
 - **Key Features**:
@@ -17,7 +17,7 @@ This document tracks implemented features and planned milestones for the spec-to
   - Configuration via `.specallowlist` or `pyproject.toml`
 
 #### Markdown Link Validation (`check-links`)
-- **Command**: `spec-tools check-links`
+- **Command**: `spec-check check-links`
 - **Specification**: SPEC-001 (40 requirements)
 - **Description**: Validates hyperlinks in markdown files
 - **Key Features**:
@@ -29,7 +29,7 @@ This document tracks implemented features and planned milestones for the spec-to
   - Configuration via `.speclinkconfig` or `pyproject.toml`
 
 #### Spec-to-Test Coverage Validation (`check-coverage`)
-- **Command**: `spec-tools check-coverage`
+- **Command**: `spec-check check-coverage`
 - **Specification**: N/A (core utility)
 - **Description**: Ensures 100% traceability between specifications and tests
 - **Key Features**:
@@ -40,7 +40,7 @@ This document tracks implemented features and planned milestones for the spec-to
   - Lists tests without requirement markers
 
 #### Spec-to-Test Structure Validation (`check-structure`)
-- **Command**: `spec-tools check-structure`
+- **Command**: `spec-check check-structure`
 - **Specification**: N/A (core utility)
 - **Description**: Enforces consistent spec-to-test file structure alignment
 - **Key Features**:
@@ -51,7 +51,7 @@ This document tracks implemented features and planned milestones for the spec-to
   - Configuration via `pyproject.toml`
 
 #### Markdown Schema Validation (`check-schema`)
-- **Command**: `spec-tools check-schema`
+- **Command**: `spec-check check-schema`
 - **Specification**: SPEC-002 (59 requirements)
 - **Description**: Validates markdown files against a defined structural schema
 - **Key Features**:
@@ -91,7 +91,7 @@ Future milestone specifications are stored in `specs/future/` with `Status: Prov
 **Target**: TBD
 
 #### Semantic Test-Adherence Check (`check-semantic-test-adherence`)
-- **Command**: `spec-tools check-semantic-test-adherence`
+- **Command**: `spec-check check-semantic-test-adherence`
 - **Specification**: SPEC-003 (`specs/future/semantic-test-adherence.md`)
 - **Description**: Validates that tests marked with requirement IDs actually test the behavior specified in those requirements
 - **Key Features** (planned):

--- a/PUBLISHING.md
+++ b/PUBLISHING.md
@@ -1,6 +1,6 @@
-# Publishing spec-tools to PyPI
+# Publishing spec-check to PyPI
 
-This document explains how to publish spec-tools to PyPI using our automated release workflows.
+This document explains how to publish spec-check to PyPI using our automated release workflows.
 
 ## Overview
 
@@ -24,10 +24,10 @@ No manual action required! This allows immediate testing of merged changes.
 
 **Installation:**
 ```bash
-pip install --index-url https://test.pypi.org/simple/ --extra-index-url https://pypi.org/simple/ sdd-tools
+pip install --index-url https://test.pypi.org/simple/ --extra-index-url https://pypi.org/simple/ spec-check
 ```
 
-**Note:** The package name on PyPI is `sdd-tools` (not `spec-tools`) due to a name collision.
+**Note:** The package name on PyPI is `spec-check` (not `spec-check`) due to a name collision.
 
 ### 2. Official Releases
 
@@ -74,7 +74,7 @@ That's it! Everything else is automated.
 ```
 You: "Make a release for version 0.2.0"
 
-Claude: ✅ Release PR created: https://github.com/TradeMe/spec-tools/pull/123
+Claude: ✅ Release PR created: https://github.com/TradeMe/spec-check/pull/123
 
 Next steps:
 1. Review the PR (especially CHANGELOG.md)
@@ -84,7 +84,7 @@ Next steps:
 After merge, automatically:
 - GitHub release created
 - Package published to PyPI
-- Installation: pip install --upgrade sdd-tools
+- Installation: pip install --upgrade spec-check
 
 You: *reviews and merges PR*
 
@@ -132,9 +132,9 @@ Follow [Semantic Versioning](https://semver.org/):
 1. Go to [PyPI](https://pypi.org) and log in
 2. Navigate to your account settings → Publishing
 3. Add a new "pending publisher" with these details:
-   - **PyPI Project Name**: `spec-tools`
+   - **PyPI Project Name**: `spec-check`
    - **Owner**: `TradeMe`
-   - **Repository name**: `spec-tools`
+   - **Repository name**: `spec-check`
    - **Workflow name**: `publish.yml`
    - **Environment name**: `pypi`
 
@@ -201,10 +201,10 @@ After merging any PR to `main`:
 
 ```bash
 # Install from TestPyPI
-pip install --index-url https://test.pypi.org/simple/ --extra-index-url https://pypi.org/simple/ sdd-tools
+pip install --index-url https://test.pypi.org/simple/ --extra-index-url https://pypi.org/simple/ spec-check
 
-# Verify version (command is still spec-tools)
-spec-tools --version
+# Verify version (command is still spec-check)
+spec-check --version
 ```
 
 ### Test a Release Before Publishing
@@ -213,11 +213,11 @@ After merging a release PR:
 
 ```bash
 # Install the dev version that was just published
-pip install --index-url https://test.pypi.org/simple/ --extra-index-url https://pypi.org/simple/ sdd-tools==<version>.devXXX
+pip install --index-url https://test.pypi.org/simple/ --extra-index-url https://pypi.org/simple/ spec-check==<version>.devXXX
 
-# Run tests (command is still spec-tools)
-spec-tools lint
-spec-tools check-coverage
+# Run tests (command is still spec-check)
+spec-check lint
+spec-check check-coverage
 ```
 
 If everything looks good, proceed with creating the GitHub release.
@@ -286,12 +286,12 @@ After publishing a release:
 
 1. **Verify installation**:
    ```bash
-   pip install --upgrade sdd-tools
-   spec-tools --version  # Command is still spec-tools
+   pip install --upgrade spec-check
+   spec-check --version  # Command is still spec-check
    ```
 
 2. **Check PyPI page**:
-   - Visit https://pypi.org/project/sdd-tools/
+   - Visit https://pypi.org/project/spec-check/
    - Verify metadata, description, and links are correct
 
 3. **Update GitHub milestones** (if used):

--- a/PYPI_SETUP.md
+++ b/PYPI_SETUP.md
@@ -1,12 +1,12 @@
 # PyPI Setup Guide
 
-This guide walks through the one-time manual setup required before spec-tools can be published to PyPI.
+This guide walks through the one-time manual setup required before spec-check can be published to PyPI.
 
 ## Important Notes
 
-**Package Name:** The PyPI package is published as `sdd-tools` (not `spec-tools`) due to a name collision on PyPI. The repository and local project name remain `spec-tools`. There will be a future task to rename everything consistently.
+**Package Name:** The PyPI package is published as `spec-check`. The repository has been renamed to `spec-check`.
 
-**Installation:** Users will install with `pip install sdd-tools`
+**Installation:** Users will install with `pip install spec-check`
 
 ## Overview
 
@@ -36,21 +36,21 @@ If you don't have one:
 
 Fill in these details:
 ```
-PyPI Project Name:    sdd-tools
+PyPI Project Name:    spec-check
 Owner:                TradeMe
-Repository name:      spec-tools
+Repository name:      spec-check
 Workflow name:        publish.yml
 Environment name:     pypi
 ```
 
 5. Click **Add**
 
-**Important:** The project name must be exactly `sdd-tools`. PyPI will reserve this name for you until the first publish.
+**Important:** The project name must be exactly `spec-check`. PyPI will reserve this name for you until the first publish.
 
 ### 1.3 What This Does
 
 This tells PyPI:
-- Trust releases from the `TradeMe/spec-tools` repository
+- Trust releases from the `TradeMe/spec-check` repository
 - Only when the `publish.yml` workflow runs
 - Only when using the `pypi` GitHub environment
 - No API tokens needed - uses OIDC for secure authentication
@@ -77,9 +77,9 @@ TestPyPI is separate from PyPI:
 
 Fill in these details:
 ```
-PyPI Project Name:    sdd-tools
+PyPI Project Name:    spec-check
 Owner:                TradeMe
-Repository name:      spec-tools
+Repository name:      spec-check
 Workflow name:        publish.yml
 Environment name:     testpypi
 ```
@@ -167,13 +167,13 @@ The `release` label:
 ### 5.1 Check PyPI Configuration
 
 1. Go to https://pypi.org → Your account → Publishing
-2. You should see `sdd-tools` in "Pending publishers"
+2. You should see `spec-check` in "Pending publishers"
 3. Status should show waiting for first publish
 
 ### 5.2 Check TestPyPI Configuration (Optional - Skip if Not Set Up)
 
 1. Go to https://test.pypi.org → Your account → Publishing
-2. You should see `sdd-tools` in "Pending publishers"
+2. You should see `spec-check` in "Pending publishers"
 3. Status should show waiting for first publish
 
 **If skipped:** TestPyPI will fail gracefully and won't block releases.
@@ -202,7 +202,7 @@ The easiest test is to merge any PR to `main`:
 2. Merge it to `main`
 3. Watch the "Publish" workflow run in Actions
 4. It should publish a dev version to TestPyPI
-5. Check https://test.pypi.org/project/sdd-tools/
+5. Check https://test.pypi.org/project/spec-check/
 
 If successful, you'll see a version like `0.1.0.dev123+abc1234`
 
@@ -219,11 +219,11 @@ When you're ready for your first release:
 3. Watch for:
    - "Create Release" workflow creates GitHub release
    - "Publish" workflow publishes to PyPI
-4. Check https://pypi.org/project/sdd-tools/
+4. Check https://pypi.org/project/spec-check/
 
 If successful, your package is live and users can install with:
 ```bash
-pip install sdd-tools
+pip install spec-check
 ```
 
 ## Troubleshooting
@@ -234,7 +234,7 @@ pip install sdd-tools
 
 **Solution:**
 1. Verify the PyPI trusted publisher configuration exactly matches:
-   - Repository: `TradeMe/spec-tools`
+   - Repository: `TradeMe/spec-check`
    - Workflow: `publish.yml`
    - Environment: `pypi` (or `testpypi`)
 2. Check there are no typos
@@ -244,7 +244,7 @@ pip install sdd-tools
 
 **Problem:** Someone else registered your desired name on PyPI
 
-**Solution:** We're already using `sdd-tools` due to the `spec-tools` name collision. This is already configured correctly.
+**Solution:** We're already using `spec-check` due to the `spec-check` name collision. This is already configured correctly.
 
 ### GitHub Environment Not Found
 
@@ -318,7 +318,7 @@ Once everything is configured:
    - Dev version published to TestPyPI automatically (if TestPyPI is configured)
    - Can test immediately with:
      ```bash
-     pip install --index-url https://test.pypi.org/simple/ --extra-index-url https://pypi.org/simple/ sdd-tools
+     pip install --index-url https://test.pypi.org/simple/ --extra-index-url https://pypi.org/simple/ spec-check
      ```
    - If TestPyPI not configured: workflow succeeds anyway, just skips that step
 
@@ -327,14 +327,14 @@ Once everything is configured:
    - You merge the PR
    - GitHub release created automatically
    - Package published to PyPI automatically
-   - Available via: `pip install sdd-tools`
+   - Available via: `pip install spec-check`
 
 ## Summary Checklist
 
 **Required before first release:**
 
 - [ ] PyPI account created
-- [ ] PyPI trusted publisher configured for `sdd-tools`
+- [ ] PyPI trusted publisher configured for `spec-check`
 - [ ] GitHub `pypi` environment created (with protection)
 - [ ] GitHub `testpypi` environment created (even if not using yet)
 - [ ] GitHub `release` label created
@@ -342,7 +342,7 @@ Once everything is configured:
 **Optional (can do later):**
 
 - [ ] TestPyPI account created/recovered
-- [ ] TestPyPI trusted publisher configured for `sdd-tools`
+- [ ] TestPyPI trusted publisher configured for `spec-check`
 - [ ] First test: merge a PR and check TestPyPI
 
 That's it! You're ready to publish to PyPI even without TestPyPI configured.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# spec-tools
+# spec-check
 
-[![CI](https://github.com/calvingiles/spec-tools/workflows/CI/badge.svg)](https://github.com/calvingiles/spec-tools/actions)
+[![CI](https://github.com/TradeMe/spec-check/workflows/CI/badge.svg)](https://github.com/TradeMe/spec-check/actions)
 [![Python 3.10+](https://img.shields.io/badge/python-3.10+-blue.svg)](https://www.python.org/downloads/)
 
 Tools for spec-driven development - a toolkit for managing and validating project specifications and files.
@@ -57,21 +57,21 @@ Key features:
 ### Using uv (recommended)
 
 ```bash
-uv pip install spec-tools
+uv pip install spec-check
 ```
 
 ### Using pip
 
 ```bash
-pip install spec-tools
+pip install spec-check
 ```
 
 ### Development installation
 
 ```bash
 # Clone the repository
-git clone https://github.com/calvingiles/spec-tools.git
-cd spec-tools
+git clone https://github.com/TradeMe/spec-check.git
+cd spec-check
 
 # Install with uv
 uv venv
@@ -80,43 +80,43 @@ uv pip install -e ".[dev]"
 
 ## Configuration
 
-spec-tools can be configured via `pyproject.toml` for seamless integration with Python projects. This allows you to set default options without needing to pass command-line arguments every time.
+spec-check can be configured via `pyproject.toml` for seamless integration with Python projects. This allows you to set default options without needing to pass command-line arguments every time.
 
 ### pyproject.toml Configuration
 
-Add a `[tool.spec-tools]` section to your `pyproject.toml`:
+Add a `[tool.spec-check]` section to your `pyproject.toml`:
 
 ```toml
-[tool.spec-tools.lint]
+[tool.spec-check.lint]
 allowlist = ".specallowlist"
 use_gitignore = true
 
-[tool.spec-tools.check-links]
+[tool.spec-check.check-links]
 config = ".speclinkconfig"
 timeout = 15
 max_concurrent = 5
 check_external = true
 use_gitignore = true
 
-[tool.spec-tools.check-schema]
+[tool.spec-check.check-schema]
 config = ".specschemaconfig"
 use_gitignore = true
 ```
 
 ### Configuration Options
 
-#### Lint Command (`[tool.spec-tools.lint]`)
+#### Lint Command (`[tool.spec-check.lint]`)
 - `allowlist` (string): Path to allowlist file (default: `.specallowlist`)
 - `use_gitignore` (boolean): Respect .gitignore patterns (default: `true`)
 
-#### Check Links Command (`[tool.spec-tools.check-links]`)
+#### Check Links Command (`[tool.spec-check.check-links]`)
 - `config` (string): Path to config file for private URLs (default: `.speclinkconfig`)
 - `timeout` (integer): Timeout for external URL requests in seconds (default: `10`)
 - `max_concurrent` (integer): Maximum concurrent external URL requests (default: `10`)
 - `check_external` (boolean): Validate external URLs (default: `true`)
 - `use_gitignore` (boolean): Respect .gitignore patterns (default: `true`)
 
-#### Check Schema Command (`[tool.spec-tools.check-schema]`)
+#### Check Schema Command (`[tool.spec-check.check-schema]`)
 - `config` (string): Path to schema config file (default: `.specschemaconfig`)
 - `use_gitignore` (boolean): Respect .gitignore patterns (default: `true`)
 
@@ -159,19 +159,19 @@ Then run the linter:
 
 ```bash
 # Lint the current directory
-spec-tools lint
+spec-check lint
 
 # Lint a specific directory
-spec-tools lint /path/to/project
+spec-check lint /path/to/project
 
 # Use a custom allowlist file
-spec-tools lint --allowlist .myallowlist
+spec-check lint --allowlist .myallowlist
 
 # Don't respect .gitignore patterns
-spec-tools lint --no-gitignore
+spec-check lint --no-gitignore
 
 # Verbose output
-spec-tools lint --verbose
+spec-check lint --verbose
 ```
 
 ### Exit Codes
@@ -184,7 +184,7 @@ This makes it easy to integrate into CI/CD pipelines:
 ```yaml
 # .github/workflows/ci.yml
 - name: Validate file allowlist
-  run: spec-tools lint
+  run: spec-check lint
 ```
 
 ### Check Links Command
@@ -193,25 +193,25 @@ Validate all hyperlinks in your markdown documentation:
 
 ```bash
 # Check links in current directory
-spec-tools check-links
+spec-check check-links
 
 # Check links in a specific directory
-spec-tools check-links /path/to/docs
+spec-check check-links /path/to/docs
 
 # Skip external URL validation (faster)
-spec-tools check-links --no-external
+spec-check check-links --no-external
 
 # Use a custom config file for private URLs
-spec-tools check-links --config .myconfigfile
+spec-check check-links --config .myconfigfile
 
 # Set timeout for external URLs (default: 10 seconds)
-spec-tools check-links --timeout 30
+spec-check check-links --timeout 30
 
 # Limit concurrent requests (default: 10)
-spec-tools check-links --max-concurrent 5
+spec-check check-links --max-concurrent 5
 
 # Verbose output
-spec-tools check-links --verbose
+spec-check check-links --verbose
 ```
 
 #### Private URL Configuration
@@ -242,7 +242,7 @@ http://127.0.0.1:
 ```yaml
 # .github/workflows/ci.yml
 - name: Validate documentation links
-  run: spec-tools check-links --no-external  # Skip external URLs in CI
+  run: spec-check check-links --no-external  # Skip external URLs in CI
 ```
 
 ### Check Coverage Command
@@ -251,13 +251,13 @@ Ensure all spec requirements have corresponding tests:
 
 ```bash
 # Check coverage in current directory
-spec-tools check-coverage
+spec-check check-coverage
 
 # Check coverage in a specific directory
-spec-tools check-coverage /path/to/project
+spec-check check-coverage /path/to/project
 
 # Use custom specs and tests directories
-spec-tools check-coverage --specs-dir my-specs --tests-dir my-tests
+spec-check check-coverage --specs-dir my-specs --tests-dir my-tests
 ```
 
 #### Marking Tests with Requirements
@@ -286,7 +286,7 @@ def test_reference_style_links():
 ```yaml
 # .github/workflows/ci.yml
 - name: Validate spec coverage
-  run: spec-tools check-coverage
+  run: spec-check check-coverage
 ```
 
 ### Check Structure Command
@@ -295,13 +295,13 @@ Validate spec-to-test structure alignment:
 
 ```bash
 # Check structure in current directory
-spec-tools check-structure
+spec-check check-structure
 
 # Check structure in a specific directory
-spec-tools check-structure /path/to/project
+spec-check check-structure /path/to/project
 
 # Use custom specs and tests directories
-spec-tools check-structure --specs-dir my-specs --tests-dir my-tests
+spec-check check-structure --specs-dir my-specs --tests-dir my-tests
 ```
 
 #### Structure Conventions
@@ -317,7 +317,7 @@ This allows unit tests without corresponding specs while ensuring all specs have
 ```yaml
 # .github/workflows/ci.yml
 - name: Validate spec structure
-  run: spec-tools check-structure
+  run: spec-check check-structure
 ```
 
 ## Pattern Syntax
@@ -415,7 +415,7 @@ flit build
 
 ## Roadmap
 
-Future tools planned for spec-tools:
+Future tools planned for spec-check:
 
 - **spec-graph**: Visualize dependencies between spec files
 - **spec-init**: Initialize new spec-driven projects

--- a/RELEASE_PROCESS.md
+++ b/RELEASE_PROCESS.md
@@ -66,8 +66,8 @@ Before:
 ## [0.1.0] - 2025-01-15
 ...
 
-[Unreleased]: https://github.com/TradeMe/spec-tools/compare/v0.1.0...HEAD
-[0.1.0]: https://github.com/TradeMe/spec-tools/releases/tag/v0.1.0
+[Unreleased]: https://github.com/TradeMe/spec-check/compare/v0.1.0...HEAD
+[0.1.0]: https://github.com/TradeMe/spec-check/releases/tag/v0.1.0
 ```
 
 After (for version 0.2.0 on 2025-10-26):
@@ -85,9 +85,9 @@ After (for version 0.2.0 on 2025-10-26):
 ## [0.1.0] - 2025-01-15
 ...
 
-[Unreleased]: https://github.com/TradeMe/spec-tools/compare/v0.2.0...HEAD
-[0.2.0]: https://github.com/TradeMe/spec-tools/compare/v0.1.0...v0.2.0
-[0.1.0]: https://github.com/TradeMe/spec-tools/releases/tag/v0.1.0
+[Unreleased]: https://github.com/TradeMe/spec-check/compare/v0.2.0...HEAD
+[0.2.0]: https://github.com/TradeMe/spec-check/compare/v0.1.0...v0.2.0
+[0.1.0]: https://github.com/TradeMe/spec-check/releases/tag/v0.1.0
 ```
 
 **Critical:** The content under the version header becomes the GitHub release notes!
@@ -146,7 +146,7 @@ See [CHANGELOG.md](./CHANGELOG.md) for details.
 ## Installation After Release
 
 \`\`\`bash
-pip install --upgrade spec-tools
+pip install --upgrade spec-check
 \`\`\`
 
 🤖 Generated with [Claude Code](https://claude.com/claude-code)" \
@@ -176,7 +176,7 @@ Tell the user:
 - Package published to PyPI
 - PR commented with release link
 
-You can then install with: `pip install --upgrade spec-tools`
+You can then install with: `pip install --upgrade spec-check`
 ```
 
 ## Common Scenarios
@@ -185,7 +185,7 @@ You can then install with: `pip install --upgrade spec-tools`
 
 Same process, just use version like `0.2.0-alpha.1`. The automation will:
 - Mark the GitHub release as "pre-release"
-- Still publish to PyPI (users can opt-in with `pip install spec-tools==0.2.0-alpha.1`)
+- Still publish to PyPI (users can opt-in with `pip install spec-check==0.2.0-alpha.1`)
 
 ### Patch Release
 
@@ -238,6 +238,6 @@ After the user merges and the release is published, you can:
 
 1. Verify the release was created: Check GitHub releases
 2. Verify PyPI publishing: Check Actions > Publish workflow
-3. Test installation: `pip install --upgrade spec-tools==VERSION`
+3. Test installation: `pip install --upgrade spec-check==VERSION`
 
 The user might ask you to verify - if so, check the GitHub releases page and workflow runs.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,14 +6,14 @@ build-backend = "flit_core.buildapi"
 name = "spec_tools"
 
 [project]
-name = "sdd-tools"
+name = "spec-check"
 version = "0.1.0"
 description = "Tools for spec-driven development - validate specifications, test coverage, file structure, and documentation links"
 readme = "README.md"
 requires-python = ">=3.10"
 license = {text = "MIT"}
 authors = [
-    {name = "spec-tools contributors"}
+    {name = "spec-check contributors"}
 ]
 keywords = [
     "spec",
@@ -52,10 +52,10 @@ dependencies = [
 ]
 
 [project.urls]
-Homepage = "https://github.com/TradeMe/spec-tools"
-Repository = "https://github.com/TradeMe/spec-tools"
-Issues = "https://github.com/TradeMe/spec-tools/issues"
-Changelog = "https://github.com/TradeMe/spec-tools/releases"
+Homepage = "https://github.com/TradeMe/spec-check"
+Repository = "https://github.com/TradeMe/spec-check"
+Issues = "https://github.com/TradeMe/spec-check/issues"
+Changelog = "https://github.com/TradeMe/spec-check/releases"
 
 [project.optional-dependencies]
 dev = [
@@ -66,6 +66,7 @@ dev = [
 ]
 
 [project.scripts]
+spec-check = "spec_tools.cli:main"
 spec-tools = "spec_tools.cli:main"
 spec-lint = "spec_tools.cli:main"
 
@@ -115,13 +116,13 @@ exclude_lines = [
     "if TYPE_CHECKING:",
 ]
 
-# spec-tools configuration (dogfooding our own tool!)
-[tool.spec-tools.lint]
+# spec-check configuration (dogfooding our own tool!)
+[tool.spec-check.lint]
 allowlist = ".specallowlist"
 use_gitignore = true
 
-[tool.spec-tools.check-coverage]
+[tool.spec-check.check-coverage]
 min_coverage = 49.0
 
-[tool.spec-tools.check-schema]
+[tool.spec-check.check-schema]
 use_gitignore = true

--- a/spec_tools/config.py
+++ b/spec_tools/config.py
@@ -15,7 +15,7 @@ else:
 
 
 class Config:
-    """Configuration container for spec-tools settings."""
+    """Configuration container for spec-check settings."""
 
     def __init__(self, config_dict: dict[str, Any] | None = None):
         """Initialize configuration.
@@ -130,8 +130,9 @@ def load_config(root_dir: Path | None = None) -> Config:
         with open(pyproject_path, "rb") as f:
             data = tomllib.load(f)
 
-        # Extract tool.spec-tools section
-        tool_config = data.get("tool", {}).get("spec-tools", {})
+        # Extract tool.spec-check section (with fallback to spec-tools for backward compatibility)
+        tool = data.get("tool", {})
+        tool_config = tool.get("spec-check", tool.get("spec-tools", {}))
         return Config(tool_config)
     except Exception:
         # If there's any error reading the file, return empty config

--- a/test-project/README.md
+++ b/test-project/README.md
@@ -1,6 +1,6 @@
 # Test Project
 
-This is a test project to verify spec-tools works with pyproject.toml configuration.
+This is a test project to verify spec-check works with pyproject.toml configuration.
 
 ## Features
 

--- a/test-project/pyproject.toml
+++ b/test-project/pyproject.toml
@@ -5,25 +5,25 @@ build-backend = "flit_core.buildapi"
 [project]
 name = "test-project"
 version = "0.1.0"
-description = "Test project for spec-tools"
+description = "Test project for spec-check"
 requires-python = ">=3.8"
 
 [project.optional-dependencies]
 dev = [
-    "spec-tools",
+    "spec-check",
 ]
 
-[tool.spec-tools.lint]
+[tool.spec-check.lint]
 allowlist = ".specallowlist"
 use_gitignore = true
 
-[tool.spec-tools.check-links]
+[tool.spec-check.check-links]
 config = ".speclinkconfig"
 timeout = 15
 max_concurrent = 5
 check_external = true
 use_gitignore = true
 
-[tool.spec-tools.check-schema]
+[tool.spec-check.check-schema]
 config = ".specschemaconfig"
 use_gitignore = true

--- a/uv.lock
+++ b/uv.lock
@@ -619,7 +619,7 @@ wheels = [
 ]
 
 [[package]]
-name = "sdd-tools"
+name = "spec-check"
 version = "0.1.0"
 source = { editable = "." }
 dependencies = [


### PR DESCRIPTION
- Update package name from sdd-tools to spec-check in pyproject.toml
- Add spec-check as primary CLI command while maintaining spec-tools for backward compatibility
- Update all documentation files (README.md, CLAUDE.md, FEATURES.md, PUBLISHING.md, PYPI_SETUP.md, RELEASE_PROCESS.md, CHANGELOG.md)
- Update GitHub workflow files to use new repository URLs and package name
- Update config.py to support both tool.spec-check and tool.spec-tools configurations (with spec-check taking precedence)
- Update test-project configuration to use spec-check
- Update workflow README and prepare-release workflow URLs

🤖 Generated with [Claude Code](https://claude.com/claude-code)