### PR TITLE
fix: Correct AttributeError in DSL validator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Release workflow now automatically publishes to PyPI in the same workflow
 - Added `pull-requests: write` permission to enable PR commenting
 - Eliminated manual intervention requirement for PyPI publishing
+- Fixed AttributeError in DSL validator where `section_def.level` was incorrectly used instead of `section_def.heading_level` (#25)
 
 ### Changed
 - Merged release creation and PyPI publishing into single workflow for reliability

--- a/spec_check/dsl/validator.py
+++ b/spec_check/dsl/validator.py
@@ -380,10 +380,11 @@ class DSLValidator:
             if section_def.required:
                 found = doc_ctx.section_tree.find_section(section_def.heading)
                 if not found:
-                    heading_prefix = "#" * section_def.level
+                    heading_prefix = "#" * section_def.heading_level
                     heading_text = section_def.heading
                     suggestion = (
-                        f"Add a level-{section_def.level} heading: {heading_prefix} {heading_text}"
+                        f"Add a level-{section_def.heading_level} heading: "
+                        f"{heading_prefix} {heading_text}"
                     )
                     self.errors.append(
                         ValidationError(


### PR DESCRIPTION
## Problem

Fixes #25

The DSL validator incorrectly accessed `section_def.level` instead of `section_def.heading_level` on `SectionSpec` objects, causing an `AttributeError` when validating specs with missing required sections.

```
AttributeError: 'SectionSpec' object has no attribute 'level'
```

## Solution

This PR follows the red-green TDD approach:

### RED Phase ✅
- Added test `test_validate_missing_required_section` that creates a Job spec without the required "Context" section
- Test failed with the expected AttributeError before the fix

### GREEN Phase ✅  
- Fixed `validator.py` line 383 and 386 to use `section_def.heading_level` instead of `section_def.level`
- Test now passes
- All 271 tests pass

## Changes

**Files Modified:**
- `spec_check/dsl/validator.py` - Fixed attribute name from `.level` to `.heading_level` (2 locations)
- `tests/test_dsl_coverage.py` - Added regression test
- `CHANGELOG.md` - Documented the fix

## Testing

```bash
# RED: Test fails before fix
pytest tests/test_dsl_coverage.py::TestValidator::test_validate_missing_required_section
# AttributeError: 'SectionSpec' object has no attribute 'level'

# GREEN: Test passes after fix  
pytest tests/test_dsl_coverage.py::TestValidator::test_validate_missing_required_section
# PASSED

# All tests pass
pytest tests/ -q
# 271 passed, 1 skipped
```

✅ All linters passing  
✅ All 271 tests passing  
✅ 75% code coverage maintained  

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)