### PR TITLE
fix: Use package metadata for version reporting (#32)

### DIFF
--- a/spec_check/__init__.py
+++ b/spec_check/__init__.py
@@ -1,6 +1,12 @@
 """spec-check: Tools for spec-driven development."""
 
-__version__ = "0.1.0"
+from importlib.metadata import PackageNotFoundError, version
+
+try:
+    __version__ = version("spec-check")
+except PackageNotFoundError:
+    # Package not installed, use a default for development
+    __version__ = "0.0.0-dev"
 
 from .linter import LintResult, SpecLinter
 from .markdown_link_validator import (

--- a/spec_check/cli.py
+++ b/spec_check/cli.py
@@ -4,6 +4,7 @@ import argparse
 import sys
 from pathlib import Path
 
+from . import __version__
 from .config import load_config, merge_config_with_args
 from .dsl.registry import SpecTypeRegistry
 from .dsl.validator import DSLValidator
@@ -306,7 +307,7 @@ def main(argv: list | None = None) -> int:
     parser.add_argument(
         "--version",
         action="version",
-        version="%(prog)s 0.1.0",
+        version=f"%(prog)s {__version__}",
     )
 
     # Create subparsers for different tools

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,39 @@
+"""Tests for CLI functionality."""
+
+import subprocess
+import sys
+
+
+def test_version_flag_reports_package_version():
+    """Test that --version reports the correct package version from metadata.
+
+    This test reproduces issue #32 where spec-check --version reports
+    an outdated hardcoded version (0.1.0) instead of the actual installed
+    package version from package metadata.
+
+    The version should be sourced from importlib.metadata.version('spec-check')
+    rather than hardcoded in the source.
+    """
+    # Run spec-check --version
+    result = subprocess.run(
+        [sys.executable, "-m", "spec_check.cli", "--version"],
+        capture_output=True,
+        text=True,
+    )
+
+    # Should exit successfully
+    assert result.returncode == 0
+
+    # Get the actual package version
+    from importlib.metadata import version
+
+    expected_version = version("spec-check")
+
+    # Version output should contain the package version
+    # Format is "spec-check <version>"
+    version_output = result.stdout.strip()
+
+    assert f"spec-check {expected_version}" in version_output, (
+        f"Expected version output to contain 'spec-check {expected_version}', "
+        f"but got: {version_output}"
+    )


### PR DESCRIPTION
## Summary
Fixes #32 - spec-check --version now reports the correct package version from metadata instead of a hardcoded outdated version.

## Problem
Previously, `spec-check --version` reported a hardcoded version (0.1.0) that was never updated when new versions were released. This made it impossible for users to verify which version was actually installed.

```bash
$ spec-check --version
spec-check 0.1.0  # ❌ Outdated!

$ uv pip freeze | grep spec-check
spec-check==0.1.2  # ✓ Actual version
```

## Solution
- Modified `spec_check/__init__.py` to use `importlib.metadata.version('spec-check')` instead of hardcoded `__version__` string
- Added fallback to "0.0.0-dev" when package is not installed (for development)
- Updated `spec_check/cli.py` to import and use `__version__` from `__init__.py`
- Added `test_cli.py` with `test_version_flag_reports_package_version()` to ensure version is sourced from package metadata

## Testing
- ✅ New test: `test_version_flag_reports_package_version()` - RED/GREEN TDD approach
- ✅ All 273 tests passing (272 passed, 1 skipped)
- ✅ All linters passing (ruff check, ruff format)
- ✅ Manual verification: `uv run spec-check --version` now reports "spec-check 0.1.2"

## Implementation Details
The version is now sourced from the package's metadata (set in `pyproject.toml` during build), which means it automatically stays in sync with releases. No more manual version updates in multiple locations.

```python
# Before:
__version__ = "0.1.0"  # Must be manually updated

# After:
try:
    __version__ = version("spec-check")  # Automatically correct
except PackageNotFoundError:
    __version__ = "0.0.0-dev"  # Development fallback
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>