### PR TITLE
fix: Auto-ignore VCS directories (.git, .hg, .svn, .bzr) (#31)

### DIFF
--- a/spec_check/linter.py
+++ b/spec_check/linter.py
@@ -48,6 +48,19 @@ class SpecLinter:
     DEFAULT_ALLOWLIST_FILE = ".specallowlist"
     DEFAULT_IGNORE_FILE = ".gitignore"
 
+    # VCS directories that are always ignored, regardless of .gitignore
+    # This matches behavior of standard tools like ripgrep, fd, and tree
+    VCS_IGNORE_PATTERNS = [
+        ".git",  # Git control files (submodules use .git as a file)
+        ".git/",  # Git directories
+        ".hg",  # Mercurial control files
+        ".hg/",  # Mercurial directories
+        ".svn",  # Subversion control files
+        ".svn/",  # Subversion directories
+        ".bzr",  # Bazaar control files
+        ".bzr/",  # Bazaar directories
+    ]
+
     def __init__(
         self,
         root_dir: Path | None = None,
@@ -118,9 +131,11 @@ class SpecLinter:
                         if line.strip() and not line.strip().startswith("#")
                     ]
 
-        # Always ignore .git directory
-        if ".git" not in ignore_patterns and ".git/" not in ignore_patterns:
-            ignore_patterns.append(".git/")
+        # Always ignore VCS directories (like ripgrep, fd, tree do)
+        # Add patterns that aren't already in ignore_patterns
+        for vcs_pattern in self.VCS_IGNORE_PATTERNS:
+            if vcs_pattern not in ignore_patterns:
+                ignore_patterns.append(vcs_pattern)
 
         return allowlist_patterns, ignore_patterns
 


### PR DESCRIPTION
## Summary

Fixes #31 - `spec-check lint` now automatically ignores all VCS control directories and files, matching the behavior of standard file linters like ripgrep, fd, and tree.

### Changes

- Added `VCS_IGNORE_PATTERNS` constant covering `.git`, `.hg`, `.svn`, `.bzr` (both as files and directories)
- Updated `load_patterns()` to automatically include all VCS patterns regardless of `.gitignore` contents
- Added comprehensive test `test_vcs_directories_auto_ignored()` covering all VCS systems

### Root Cause

The original implementation only had `.git/` pattern, which:
- Didn't match `.git` files (used by git submodules: `gitdir: ../.git`)
- Didn't cover other VCS systems (Mercurial, Subversion, Bazaar)

### Testing

The new test verifies:
- All 4 VCS systems (Git, Mercurial, Subversion, Bazaar) as directories with files
- Edge case of `.git` as a file (submodule scenario)
- Only non-VCS files are reported by the linter

All 272 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)