### PR TITLE
Release v0.1.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.3] - 2025-10-29
+
+### Fixed
+- Fixed `spec-check --version` to report correct package version from metadata instead of hardcoded 0.1.0 (#32)
+- Fixed `spec-check lint` to automatically ignore all VCS control directories (.git, .hg, .svn, .bzr) regardless of .gitignore (#31)
+
 ## [0.1.2] - 2025-10-28
 
 ### Fixed
@@ -69,7 +75,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Development status updated to Alpha
 - Added flit as dev dependency for building distributions
 
-[Unreleased]: https://github.com/TradeMe/spec-check/compare/v0.1.2...HEAD
+[Unreleased]: https://github.com/TradeMe/spec-check/compare/v0.1.3...HEAD
+[0.1.3]: https://github.com/TradeMe/spec-check/compare/v0.1.2...v0.1.3
 [0.1.2]: https://github.com/TradeMe/spec-check/compare/v0.1.1...v0.1.2
 [0.1.1]: https://github.com/TradeMe/spec-check/compare/v0.1.0...v0.1.1
 [0.1.0]: https://github.com/TradeMe/spec-check/releases/tag/v0.1.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ name = "spec_check"
 
 [project]
 name = "spec-check"
-version = "0.1.2"
+version = "0.1.3"
 description = "Tools for spec-driven development - validate specifications, test coverage, file structure, and documentation links"
 readme = "README.md"
 requires-python = ">=3.10"


### PR DESCRIPTION
## Release v0.1.3

This patch release includes two bug fixes:

### Fixed
- Fixed `spec-check --version` to report correct package version from metadata instead of hardcoded 0.1.0 (#32)
- Fixed `spec-check lint` to automatically ignore all VCS control directories (.git, .hg, .svn, .bzr) regardless of .gitignore (#31)

### Changes
- Updated CHANGELOG.md with v0.1.3 release notes
- Bumped version in pyproject.toml to 0.1.3

### PRs Included
- #33: fix: Report correct package version from metadata
- #34: fix: Auto-ignore VCS directories (.git, .hg, .svn, .bzr)

### Release Process
This PR has the `release` label, which will automatically:
1. Run all CI checks (tests and linters)
2. Create a GitHub release with tag v0.1.3 when merged
3. Publish the package to PyPI using trusted publishing (OIDC)

🤖 Generated with [Claude Code](https://claude.com/claude-code)