### PR TITLE
feat: Support file path references in validate-dsl (#36)

### DIFF
--- a/spec_check/dsl/id_registry.py
+++ b/spec_check/dsl/id_registry.py
@@ -173,6 +173,37 @@ class IDRegistry:
         """Get a class instance by ID."""
         return self.classes.get(class_id)
 
+    def get_module_by_file(self, file_path: Path) -> ModuleInstance | None:
+        """
+        Get a module instance by its file path.
+
+        This enables resolving cross-document references that use relative file paths
+        instead of module IDs (e.g., './011-deployment-architecture.md' → 'ADR-011').
+
+        Args:
+            file_path: Absolute or relative path to the module file
+
+        Returns:
+            ModuleInstance if found, None otherwise
+        """
+        # Resolve to absolute path for comparison
+        try:
+            target_path = file_path.resolve()
+        except (OSError, RuntimeError):
+            # Path doesn't exist or can't be resolved
+            return None
+
+        # Search all registered modules for matching file path
+        for module in self.modules.values():
+            try:
+                if module.file_path.resolve() == target_path:
+                    return module
+            except (OSError, RuntimeError):
+                # Module file path can't be resolved, skip it
+                continue
+
+        return None
+
     def find_class_in_module(self, class_id: str, module_id: str) -> ClassInstance | None:
         """
         Find a class instance within a specific module.

--- a/uv.lock
+++ b/uv.lock
@@ -620,7 +620,7 @@ wheels = [
 
 [[package]]
 name = "spec-check"
-version = "0.1.2"
+version = "0.1.3"
 source = { editable = "." }
 dependencies = [
     { name = "markdown-it-py" },


### PR DESCRIPTION
## Summary

Adds support for cross-document references using relative file paths in the DSL validator, resolving #36.

Previously, `validate-dsl` could only resolve module references by ID (e.g., `ADR-011`). Now it also supports standard markdown file path links (e.g., `./ADR-011.md`), enabling validation of real-world specification repositories that use conventional markdown linking.

## Changes

### Core Implementation

1. **`IDRegistry.get_module_by_file()`** (`spec_check/dsl/id_registry.py:176-205`)
   - New method to lookup modules by file path
   - Resolves paths to absolute for comparison
   - Handles OSError gracefully for non-existent paths

2. **`ReferenceResolver._is_file_path()`** (`spec_check/dsl/reference_resolver.py:276-292`)
   - Detects if a target looks like a file path vs module ID
   - Checks for path separators and relative path indicators

3. **`ReferenceResolver._resolve_by_file_path()`** (`spec_check/dsl/reference_resolver.py:294-318`)
   - Converts relative file paths to absolute
   - Re-adds `.md` extension stripped by `_extract_module_id()`
   - Resolves relative to source file's directory

4. **`ReferenceResolver._resolve_module_reference()`** (`spec_check/dsl/reference_resolver.py:112-140`)
   - Updated to try file path resolution when ID lookup fails
   - Falls back to existing error reporting if both fail

### Testing

- Added `test_file_path_reference_resolution()` in `tests/test_dsl_coverage.py:351-414`
- Creates ADR documents with cross-references using file paths
- Verifies references resolve without errors
- All 275 tests pass

## Examples

### Before
```markdown
# ADR-015: Access Control

## Adheres To
- [ADR-011](./ADR-011.md)  ❌ Error: Module reference './ADR-011' not found
```

### After
```markdown
# ADR-015: Access Control

## Adheres To
- [ADR-011](./ADR-011.md)  ✅ Resolves to module ADR-011
```

## Impact

This makes `validate-dsl` compatible with standard markdown editing tools (GitHub, VSCode, etc.) that expect file paths for local links, removing a major barrier to adoption.

## Testing Checklist

- [x] All 275 tests pass
- [x] Ruff linting passes
- [x] Ruff formatting passes  
- [x] Project linters pass
- [x] Test added for new functionality
- [x] Follows TDD (RED-GREEN)

Closes #36

🤖 Generated with [Claude Code](https://claude.com/claude-code)